### PR TITLE
Palm Facing Forwards: with bug

### DIFF
--- a/src/main/java/com/almasb/fxglgames/HandTrackingApp.java
+++ b/src/main/java/com/almasb/fxglgames/HandTrackingApp.java
@@ -133,6 +133,12 @@ public class HandTrackingApp extends GameApplication {
                         .concat("\n")
                         .concat("Is pinky curled: ")
                         .concat(getService(HandGestureService.class).getPinkyDown())
+                        .concat("\n")
+                        .concat("Palm Facing Forwards: ")
+                        .concat(getService(HandGestureService.class).palmForwardsProperty())
+                        .concat("\n")
+                        .concat("Current Orientation: ")
+                        .concat(getService(HandGestureService.class).currentOrientationProperty())
         );
 
         addUINode(text, 50, 50);

--- a/src/main/java/com/almasb/fxglgames/tracking/HandGestureService.java
+++ b/src/main/java/com/almasb/fxglgames/tracking/HandGestureService.java
@@ -42,6 +42,8 @@ public final class HandGestureService extends EngineService {
 
     public BooleanProperty pinkyDown = new SimpleBooleanProperty(false);
 
+    public BooleanProperty palmForwards = new SimpleBooleanProperty(false);
+
     public BooleanProperty thumbCurled = new SimpleBooleanProperty(false);
 
     private BlockingQueue<Hand> dataQueue = new ArrayBlockingQueue<>(1000);
@@ -113,6 +115,8 @@ public final class HandGestureService extends EngineService {
         return currentOrientation;
     }
 
+    public BooleanProperty palmForwardsProperty() { return palmForwards; }
+
     public void setRawDataHandler(BiConsumer<Hand, HandMetadataAnalyser> rawDataHandler) {
         this.rawDataHandler = rawDataHandler;
     }
@@ -157,6 +161,8 @@ public final class HandGestureService extends EngineService {
             pinkyDown.set(GeometricGestureEvaluator.isFingerDown(item, HandLandmark.PINKY_TIP));
 
             thumbCurled.set(GeometricGestureEvaluator.isFingerDown(item, HandLandmark.THUMB_TIP));
+
+            palmForwards.set(GeometricGestureEvaluator.getPalmFacingFowards(item));
 
         } catch (InterruptedException e) {
             log.warning("Cannot take item from queue", e);

--- a/src/main/java/com/almasb/fxglgames/tracking/gestures/GeometricGestureEvaluator.java
+++ b/src/main/java/com/almasb/fxglgames/tracking/gestures/GeometricGestureEvaluator.java
@@ -123,24 +123,29 @@ public class GeometricGestureEvaluator implements GestureEvaluator {
     // Not currently working
     public static boolean getPalmFacingFowards(Hand hand)
     {
-        return !(hand.getPoint(THUMB_TIP).midpoint(hand.getPoint(THUMB_CMC)).getX() < hand.getPoint(MIDDLE_FINGER_MCP).getX());
+        // Find raw direction (regardless of hands rotation)
+        if(hand.getPoint(INDEX_FINGER_MCP).getX() > hand.getPoint(PINKY_MCP).getX())
+        {
+            // Check if hand facing down or up and use to deduce if facing forward or back.
+            if(hand.getPoint(WRIST).getY() < hand.getPoint(INDEX_FINGER_MCP).midpoint(hand.getPoint(PINKY_MCP)).getY())
+            {
+                return false;
+            } else {
+                return true;
+            }
+        } else {
+            // Check if hand facing down or up and use to deduce if facing forward or back.
+            if(hand.getPoint(WRIST).getY() < hand.getPoint(INDEX_FINGER_MCP).midpoint(hand.getPoint(PINKY_MCP)).getY())
+            {
+                return true;
+            } else {
+                return false;
+            }
+        }
     }
 
     public static HandOrientation getOrientation(Hand hand)
     {
-        // Commented out code is functional but only works on left-right or up-down
-
-//        if(hand.getPoint(INDEX_FINGER_MCP).midpoint(hand.getPoint(RING_FINGER_MCP)).getY() > hand.getPoint(WRIST).getY())
-//        {
-//            return HandOrientation.DOWN;
-//        }
-//        return HandOrientation.UP;
-
-//        if(hand.getPoint(INDEX_FINGER_MCP).midpoint(hand.getPoint(RING_FINGER_MCP)).getX() > hand.getPoint(WRIST).getX())
-//        {
-//            return HandOrientation.LEFT;
-//        }
-//        return HandOrientation.RIGHT;
 
         boolean palmForwards = getPalmFacingFowards(hand);
         // ISSUE: LEFT-RIGHT ONLY WORKS WITH PALM FACING FORWARDS
@@ -152,17 +157,17 @@ public class GeometricGestureEvaluator implements GestureEvaluator {
         Point3D lowerPoint = hand.getPoint(WRIST);
         if(leftPoint.getY() < rightPoint.getY() && leftPoint.getY() < upperPoint.getY() && leftPoint.getY() < lowerPoint.getY())
         {
-//            if(palmForwards) {
+            if(palmForwards) {
                 return HandOrientation.RIGHT;
-//            } else {
-//                return HandOrientation.LEFT;
-//            }
-        } else if (rightPoint.getY() < upperPoint.getY() && rightPoint.getY() < lowerPoint.getY()) {
-//            if(palmForwards) {
+            } else {
                 return HandOrientation.LEFT;
-//            } else {
-//                return HandOrientation.RIGHT;
-//            }
+            }
+        } else if (rightPoint.getY() < upperPoint.getY() && rightPoint.getY() < lowerPoint.getY()) {
+            if(palmForwards) {
+                return HandOrientation.LEFT;
+            } else {
+                return HandOrientation.RIGHT;
+            }
         } else if (upperPoint.getY() < lowerPoint.getY()) {
             return HandOrientation.UP;
         } else {


### PR DESCRIPTION
There is a small area when pointing in each direction in which the current recognition gets the palm facing forwards incorrect and thereby, the hand orientation. I believe this is because of landmark position relational issues when the hand is side to side.
Suggested fix: Separate 'lowest side' method that gets the lowest side of the hand currently, to find its 'most extreme' direction and then use that to decide which points to compare when finding the palm facing forwards/hand orientation